### PR TITLE
fixed formatting error

### DIFF
--- a/glassy/scripts/battery_status.sh
+++ b/glassy/scripts/battery_status.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 bat_state=$(upower -i $(upower -e | grep BAT) | grep state |awk '{print $2}' | tr -d '\n')
 bat_percentage=$(upower -i $(upower -e | grep BAT) | grep percentage |awk '{print $2}' | tr -d '\n')
-printf $bat_state" "$bat_percentage
+printf "%s %s" "$bat_state" "$bat_percentage"


### PR DESCRIPTION
made changes to fix the formatting error:
```py
./battery_status.sh: line 4: printf: `%': missing format character
```